### PR TITLE
Points and output fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Fixed handlings of points-based fields and output fields
+
 ## [0.1.1] - 2025-06-06
 
 ### Changed

--- a/dx/scorecard/resource.go
+++ b/dx/scorecard/resource.go
@@ -359,7 +359,7 @@ func modelToRequestBody(ctx context.Context, plan ScorecardModel, setIds bool) (
 		// Add POINTS-specific check fields
 		if scorecardType == "POINTS" {
 			checkPayload["scorecard_check_group_key"] = check.ScorecardCheckGroupKey.ValueString()
-			checkPayload["points"] = check.Points
+			checkPayload["points"] = check.Points.ValueInt32()
 		}
 
 		checks = append(checks, checkPayload)

--- a/dx/scorecard/resource.go
+++ b/dx/scorecard/resource.go
@@ -331,8 +331,8 @@ func modelToRequestBody(ctx context.Context, plan ScorecardModel, setIds bool) (
 			"filter_sql":         check.FilterSql.ValueString(),
 			"filter_message":     check.FilterMessage.ValueString(),
 			"output_enabled":     check.OutputEnabled.ValueBool(),
-			"output_type":        check.OutputType.ValueString(),
-			"output_aggregation": check.OutputAggregation.ValueString(),
+			"output_type":        nil,
+			"output_aggregation": nil,
 			"estimated_dev_days": estimatedDevDaysValue,
 			"external_url":       check.ExternalUrl.ValueString(),
 			"published":          check.Published.ValueBool(),
@@ -340,6 +340,11 @@ func modelToRequestBody(ctx context.Context, plan ScorecardModel, setIds bool) (
 
 		if setIds {
 			checkPayload["id"] = check.Id.ValueString()
+		}
+
+		if checkPayload["output_enabled"] == true {
+			checkPayload["output_type"] = check.OutputType.ValueString()
+			checkPayload["output_aggregation"] = check.OutputAggregation.ValueString()
 		}
 
 		if check.OutputType.ValueString() == "custom" {
@@ -488,7 +493,7 @@ func responseBodyToModel(ctx context.Context, apiResp *dxapi.APIResponse, plan *
 				Sql:               stringOrNull(chk.Sql),
 				FilterSql:         stringOrNull(chk.FilterSql),
 				FilterMessage:     stringOrNull(chk.FilterMessage),
-				OutputEnabled:     boolApiToTF(chk.OutputEnabled, plan.Checks[i].OutputEnabled),
+				OutputEnabled:     types.BoolValue(chk.OutputEnabled),
 				OutputType:        stringOrNull(chk.OutputType),
 				OutputAggregation: stringOrNull(chk.OutputAggregation),
 				OutputCustomOptions: types.ObjectNull(map[string]attr.Type{

--- a/dx/scorecard/schema.go
+++ b/dx/scorecard/schema.go
@@ -34,7 +34,7 @@ func CheckGroupSchema() map[string]schema.Attribute {
 				stringplanmodifier.UseStateForUnknown(),
 			}},
 		"name":     schema.StringAttribute{Required: true},
-		"ordering": schema.NumberAttribute{Required: true},
+		"ordering": schema.Int32Attribute{Required: true},
 	}
 }
 

--- a/dx/scorecard/schema.go
+++ b/dx/scorecard/schema.go
@@ -53,8 +53,8 @@ func CheckSchema() map[string]schema.Attribute {
 		"filter_sql":         schema.StringAttribute{Required: true},
 		"filter_message":     schema.StringAttribute{Required: true},
 		"output_enabled":     schema.BoolAttribute{Required: true},
-		"output_type":        schema.StringAttribute{Required: true},
-		"output_aggregation": schema.StringAttribute{Required: true},
+		"output_type":        schema.StringAttribute{Optional: true},
+		"output_aggregation": schema.StringAttribute{Optional: true},
 		"output_custom_options": schema.SingleNestedAttribute{
 			Optional: true,
 			Attributes: map[string]schema.Attribute{


### PR DESCRIPTION
This fixes some incorrect handling we had around points-based scorecards and outputs.

- `checks.output_type` and `checks.output_aggregation`: only set to string values if `checks.output_enabled` is true
- `checks.points`: get the specific int32 value out of the model
- `check_groups.ordering`: Use int32 for type, not generic number
