### PR TITLE
Scorecard resource restructure

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,11 +30,13 @@ Follow these steps to run the locally-built provider rather than the one from th
   ```terraform
   provider_installation {
     dev_overrides {
-      "registry.terraform.io/get-dx/dx" = "/path/to/your/go/bin"
+      "registry.terraform.io/local/dx" = "/path/to/your/go/bin"
     }
     direct {}
   }
   ```
+
+  Note that this references `local/dx` instead of `get-dx/dx`.
 
 - In your TF module, use the `provider` as:
 
@@ -42,7 +44,7 @@ Follow these steps to run the locally-built provider rather than the one from th
   terraform {
     required_providers {
       dx = {
-        source = "registry.terraform.io/get-dx/dx"
+        source = "registry.terraform.io/local/dx"
       }
     }
   }

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ terraform {
   required_providers {
     dx = {
       source  = "registry.terraform.io/get-dx/dx"
-      version = "0.1.0"
+      version = "~> 0.1.0"
     }
   }
 }
@@ -43,28 +43,26 @@ resource "dx_scorecard" "my_example_scorecard" {
   empty_level_color              = "#cccccc"
   published                      = true
 
-  levels = [
-    {
-      key   = "bronze"
+  levels = {
+    bronze = {
       name  = "Bronze"
       color = "#FB923C"
       rank  = 1
     },
-    {
-      key   = "silver"
+    silver = {
       name  = "Silver"
       color = "#9CA3AF"
       rank  = 2
     },
-    {
-      key   = "gold"
+    gold = {
       name  = "Gold"
       color = "#FBBF24"
       rank  = 3
     },
-  ]
-  checks = [
-    {
+  }
+
+  checks = {
+    test_check = {
       name                = "Test Check"
       scorecard_level_key = "bronze"
       ordering            = 0
@@ -85,7 +83,7 @@ resource "dx_scorecard" "my_example_scorecard" {
       filter_sql            = ""
       output_custom_options = null
     },
-    {
+    another_check = {
       name                = "Another Check"
       scorecard_level_key = "silver"
       ordering            = 0
@@ -113,7 +111,7 @@ resource "dx_scorecard" "my_example_scorecard" {
       filter_sql            = ""
       output_custom_options = null
     }
-  ]
+  }
 }
 ```
 

--- a/docs/resources/scorecard.md
+++ b/docs/resources/scorecard.md
@@ -24,7 +24,7 @@ terraform {
 
 provider "dx" {}
 
-resource "dx_scorecard" "example" {
+resource "dx_scorecard" "level_based_example" {
   name                           = "Terraform Provider Scorecard"
   description                    = "This is a test scorecard"
   type                           = "LEVEL"
@@ -35,28 +35,26 @@ resource "dx_scorecard" "example" {
   empty_level_color              = "#cccccc"
   published                      = true
 
-  levels = [
-    {
-      key   = "bronze"
+  levels = {
+    bronze = {
       name  = "Bronze"
       color = "#FB923C"
       rank  = 1
     },
-    {
-      key   = "silver"
+    silver = {
       name  = "Silver"
       color = "#9CA3AF"
       rank  = 2
     },
-    {
-      key   = "gold"
+    gold = {
       name  = "Gold"
       color = "#FBBF24"
       rank  = 3
     },
-  ]
-  checks = [
-    {
+  }
+
+  checks = {
+    test_check = {
       name                = "Test Check"
       scorecard_level_key = "bronze"
       ordering            = 0
@@ -75,10 +73,11 @@ resource "dx_scorecard" "example" {
       filter_sql            = ""
       output_custom_options = null
     },
-    {
+
+    another_check = {
       name                = "Another Check"
-      scorecard_level_key = "silver"
-      ordering            = 0
+      scorecard_level_key = "bronze"
+      ordering            = 1
 
       description           = "This is a another test check"
       sql                   = <<-EOT
@@ -102,8 +101,91 @@ resource "dx_scorecard" "example" {
       filter_message        = ""
       filter_sql            = ""
       output_custom_options = null
-    }
-  ]
+    },
+
+    neat_silver_check = {
+      name                = "Neat silver check"
+      scorecard_level_key = "silver"
+      ordering            = 0
+
+      description           = "This is a neat silver check"
+      sql                   = <<-EOT
+        select 'PASS' as status, 123 as output
+      EOT
+      output_enabled        = true
+      output_type           = "duration_seconds"
+      output_aggregation    = "median"
+      external_url          = "http://example.com"
+      published             = true
+      estimated_dev_days    = 1.5
+      filter_message        = ""
+      filter_sql            = ""
+      output_custom_options = null
+    },
+  }
+}
+
+resource "dx_scorecard" "points_based_example" {
+  name                           = "Terraform Provider Scorecard - points"
+  description                    = "This is a test scorecard"
+  type                           = "POINTS"
+  entity_filter_type             = "entity_types"
+  entity_filter_type_identifiers = ["service"]
+  evaluation_frequency_hours     = 2
+  published                      = true
+
+  check_groups = {
+    group_1 = {
+      name     = "First group"
+      ordering = 0
+    },
+    group_2 = {
+      name     = "Second group"
+      ordering = 1
+    },
+  }
+
+  checks = {
+    check_1 = {
+      name                      = "Check 1"
+      scorecard_check_group_key = "group_1"
+      ordering                  = 0
+
+      description           = "This is a check in the first group"
+      sql                   = <<-EOT
+        select 'PASS' as status, 123 as output
+      EOT
+      output_enabled        = false
+      external_url          = "http://example.com"
+      published             = true
+      estimated_dev_days    = 1.5
+      filter_message        = ""
+      filter_sql            = ""
+      output_custom_options = null
+      points                = 10
+    },
+
+    check_2 = {
+      name                      = "Check 2"
+      scorecard_check_group_key = "group_2"
+      ordering                  = 0
+
+      description           = "This is a check in the second group"
+      sql                   = <<-EOT
+        select 'PASS' as status, 123 as output
+      EOT
+      output_enabled        = true
+      output_type           = "duration_seconds"
+      output_aggregation    = "median"
+      external_url          = "http://example.com"
+      published             = true
+      estimated_dev_days    = 1.5
+      filter_message        = ""
+      filter_sql            = ""
+      output_custom_options = null
+      points                = 20
+    },
+  }
 }
 ```
 
@@ -119,14 +201,14 @@ resource "dx_scorecard" "example" {
 
 ### Optional
 
-- `check_groups` (Attributes List) Groups of checks, to help organize the scorecard for entity owners (points scorecards only). (see [below for nested schema](#nestedatt--check_groups))
-- `checks` (Attributes List) List of checks that are applied to entities in the scorecard. (see [below for nested schema](#nestedatt--checks))
+- `check_groups` (Attributes Map) Groups of checks, to help organize the scorecard for entity owners (points scorecards only). (see [below for nested schema](#nestedatt--check_groups))
+- `checks` (Attributes Map) List of checks that are applied to entities in the scorecard. (see [below for nested schema](#nestedatt--checks))
 - `description` (String) Description of the scorecard.
 - `empty_level_color` (String) The color hex code to display when an entity has not achieved any levels in the scorecard (levels scorecards only).
 - `empty_level_label` (String) The label to display when an entity has not achieved any levels in the scorecard (levels scorecards only).
 - `entity_filter_sql` (String) Custom SQL used to filter entities that the scorecard should run against.
 - `entity_filter_type_identifiers` (List of String) List of entity type identifiers that the scorecard should run against.
-- `levels` (Attributes List) The levels that can be achieved in this scorecard (levels scorecards only). (see [below for nested schema](#nestedatt--levels))
+- `levels` (Attributes Map) The levels that can be achieved in this scorecard (levels scorecards only). (see [below for nested schema](#nestedatt--levels))
 - `published` (Boolean) Whether the scorecard is published.
 
 ### Read-Only
@@ -138,7 +220,6 @@ resource "dx_scorecard" "example" {
 
 Required:
 
-- `key` (String)
 - `name` (String)
 - `ordering` (Number)
 
@@ -192,7 +273,6 @@ Required:
 Required:
 
 - `color` (String)
-- `key` (String)
 - `name` (String)
 - `rank` (Number)
 

--- a/dx/dxapi/scorecard.go
+++ b/dx/dxapi/scorecard.go
@@ -79,8 +79,13 @@ type APIOutputCustomOptions struct {
 	Decimals *int32 `json:"decimals"` // TODO: "auto" or number
 }
 
-// APIResponse is the top-level response from the DX API for scorecard endpoints
-// (e.g., { "ok": true, "scorecard": { ... } })
+// APIResponse is the top-level response from the DX API for scorecard endpoints.
+//
+// Example:
+//
+// ```json
+// { "ok": true, "scorecard": { ... } }
+// ```
 type APIResponse struct {
 	Ok        bool         `json:"ok"`
 	Scorecard APIScorecard `json:"scorecard"`

--- a/dx/dxapi/scorecard.go
+++ b/dx/dxapi/scorecard.go
@@ -87,7 +87,7 @@ type APIResponse struct {
 }
 
 func (c *Client) CreateScorecard(ctx context.Context, payload map[string]interface{}) (*APIResponse, error) {
-	tflog.Debug(ctx, "Calling CreateScorecard")
+	tflog.Info(ctx, "Calling CreateScorecard")
 
 	body, err := json.MarshalIndent(payload, "", "  ")
 	if err != nil {
@@ -102,7 +102,7 @@ func (c *Client) CreateScorecard(ctx context.Context, payload map[string]interfa
 
 	setRequestHeaders(req, c)
 
-	tflog.Debug(ctx, fmt.Sprintf("Request body:\n%s", string(body)))
+	tflog.Info(ctx, fmt.Sprintf("Request body:\n%s", string(body)))
 
 	// Make the request
 	resp, err := c.httpClient.Do(req)
@@ -124,7 +124,7 @@ func (c *Client) CreateScorecard(ctx context.Context, payload map[string]interfa
 
 	// Log the API response for debugging
 	if respJson, err := json.MarshalIndent(apiResp, "", "  "); err == nil {
-		tflog.Debug(ctx, fmt.Sprintf("API Response from CreateScorecard:\n%s", string(respJson)))
+		tflog.Info(ctx, fmt.Sprintf("API Response from CreateScorecard:\n%s", string(respJson)))
 	} else {
 		tflog.Debug(ctx, "Could not marshal API response", map[string]interface{}{
 			"error": err,
@@ -175,7 +175,7 @@ func (c *Client) GetScorecard(ctx context.Context, id string) (*APIResponse, err
 }
 
 func (c *Client) UpdateScorecard(ctx context.Context, payload map[string]interface{}) (*APIResponse, error) {
-	tflog.Debug(ctx, "Calling UpdateScorecard")
+	tflog.Info(ctx, "Calling UpdateScorecard")
 
 	body, err := json.MarshalIndent(payload, "", "  ")
 	if err != nil {
@@ -190,7 +190,7 @@ func (c *Client) UpdateScorecard(ctx context.Context, payload map[string]interfa
 
 	setRequestHeaders(req, c)
 
-	tflog.Debug(ctx, fmt.Sprintf("Request body:\n%s", string(body)))
+	tflog.Info(ctx, fmt.Sprintf("Request body:\n%s", string(body)))
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
@@ -219,7 +219,7 @@ func (c *Client) UpdateScorecard(ctx context.Context, payload map[string]interfa
 
 	// Log the API response for debugging
 	if respJson, err := json.MarshalIndent(apiResp, "", "  "); err == nil {
-		tflog.Debug(ctx, fmt.Sprintf("API Response from UpdateScorecard:\n%s", string(respJson)))
+		tflog.Info(ctx, fmt.Sprintf("API Response from UpdateScorecard:\n%s", string(respJson)))
 	} else {
 		tflog.Debug(ctx, "Could not marshal API response", map[string]interface{}{
 			"error": err,

--- a/dx/scorecard/model.go
+++ b/dx/scorecard/model.go
@@ -46,6 +46,7 @@ type CheckGroupModel struct {
 
 type CheckModel struct {
 	Id            types.String `tfsdk:"id"`
+	Key           types.String `tfsdk:"key"`
 	Name          types.String `tfsdk:"name"`
 	Description   types.String `tfsdk:"description"`
 	Ordering      types.Int32  `tfsdk:"ordering"`

--- a/dx/scorecard/model.go
+++ b/dx/scorecard/model.go
@@ -14,12 +14,12 @@ type ScorecardModel struct {
 	EvaluationFrequency types.Int32  `tfsdk:"evaluation_frequency_hours"`
 
 	// Conditionally required fields for levels based scorecards
-	EmptyLevelLabel types.String `tfsdk:"empty_level_label"`
-	EmptyLevelColor types.String `tfsdk:"empty_level_color"`
-	Levels          []LevelModel `tfsdk:"levels"`
+	EmptyLevelLabel types.String          `tfsdk:"empty_level_label"`
+	EmptyLevelColor types.String          `tfsdk:"empty_level_color"`
+	Levels          map[string]LevelModel `tfsdk:"levels"`
 
 	// Conditionally required fields for points based scorecards
-	CheckGroups []CheckGroupModel `tfsdk:"check_groups"`
+	CheckGroups map[string]CheckGroupModel `tfsdk:"check_groups"`
 
 	// Optional fields
 	Description                 types.String          `tfsdk:"description"`
@@ -30,7 +30,6 @@ type ScorecardModel struct {
 }
 
 type LevelModel struct {
-	Key   types.String `tfsdk:"key"`
 	Id    types.String `tfsdk:"id"`
 	Name  types.String `tfsdk:"name"`
 	Color types.String `tfsdk:"color"`
@@ -38,7 +37,6 @@ type LevelModel struct {
 }
 
 type CheckGroupModel struct {
-	Key      types.String `tfsdk:"key"`
 	Id       types.String `tfsdk:"id"`
 	Name     types.String `tfsdk:"name"`
 	Ordering types.Int32  `tfsdk:"ordering"`

--- a/dx/scorecard/model.go
+++ b/dx/scorecard/model.go
@@ -22,11 +22,11 @@ type ScorecardModel struct {
 	CheckGroups []CheckGroupModel `tfsdk:"check_groups"`
 
 	// Optional fields
-	Description                 types.String   `tfsdk:"description"`
-	Published                   types.Bool     `tfsdk:"published"`
-	EntityFilterTypeIdentifiers []types.String `tfsdk:"entity_filter_type_identifiers"`
-	EntityFilterSql             types.String   `tfsdk:"entity_filter_sql"`
-	Checks                      []CheckModel   `tfsdk:"checks"`
+	Description                 types.String          `tfsdk:"description"`
+	Published                   types.Bool            `tfsdk:"published"`
+	EntityFilterTypeIdentifiers []types.String        `tfsdk:"entity_filter_type_identifiers"`
+	EntityFilterSql             types.String          `tfsdk:"entity_filter_sql"`
+	Checks                      map[string]CheckModel `tfsdk:"checks"`
 }
 
 type LevelModel struct {
@@ -46,7 +46,6 @@ type CheckGroupModel struct {
 
 type CheckModel struct {
 	Id            types.String `tfsdk:"id"`
-	Key           types.String `tfsdk:"key"`
 	Name          types.String `tfsdk:"name"`
 	Description   types.String `tfsdk:"description"`
 	Ordering      types.Int32  `tfsdk:"ordering"`

--- a/dx/scorecard/resource.go
+++ b/dx/scorecard/resource.go
@@ -411,7 +411,7 @@ func responseBodyToModel(ctx context.Context, apiResp *dxapi.APIResponse, state 
 	state.Name = types.StringValue(apiResp.Scorecard.Name)
 	state.Type = types.StringValue(apiResp.Scorecard.Type)
 	state.EntityFilterType = types.StringValue(apiResp.Scorecard.EntityFilterType)
-	state.EvaluationFrequency = types.Int32Value(int32(apiResp.Scorecard.EvaluationFrequency))
+	state.EvaluationFrequency = types.Int32Value(apiResp.Scorecard.EvaluationFrequency)
 
 	// ************** Conditionally required fields for levels based scorecards **************
 	state.EmptyLevelLabel = stringOrNull(apiResp.Scorecard.EmptyLevelLabel)

--- a/dx/scorecard/resource.go
+++ b/dx/scorecard/resource.go
@@ -501,7 +501,7 @@ func responseBodyToModel(ctx context.Context, apiResp *dxapi.APIResponse, state 
 			Id:                stringOrNull(chk.Id),
 			Name:              stringOrNull(chk.Name),
 			Description:       stringOrNull(chk.Description),
-			Ordering:          types.Int32Value(int32(chk.Ordering)),
+			Ordering:          types.Int32Value(chk.Ordering),
 			Sql:               stringOrNull(chk.Sql),
 			FilterSql:         stringOrNull(chk.FilterSql),
 			FilterMessage:     stringOrNull(chk.FilterMessage),

--- a/dx/scorecard/schema.go
+++ b/dx/scorecard/schema.go
@@ -13,7 +13,6 @@ import (
 
 func LevelSchema() map[string]schema.Attribute {
 	return map[string]schema.Attribute{
-		"key": schema.StringAttribute{Required: true},
 		"id": schema.StringAttribute{
 			Computed: true,
 			PlanModifiers: []planmodifier.String{
@@ -27,7 +26,6 @@ func LevelSchema() map[string]schema.Attribute {
 
 func CheckGroupSchema() map[string]schema.Attribute {
 	return map[string]schema.Attribute{
-		"key": schema.StringAttribute{Required: true},
 		"id": schema.StringAttribute{
 			Computed: true,
 			PlanModifiers: []planmodifier.String{
@@ -131,7 +129,7 @@ func ScorecardSchema() map[string]schema.Attribute {
 			Optional:    true,
 			Description: "The color hex code to display when an entity has not achieved any levels in the scorecard (levels scorecards only).",
 		},
-		"levels": schema.ListNestedAttribute{
+		"levels": schema.MapNestedAttribute{
 			Optional:    true,
 			Description: "The levels that can be achieved in this scorecard (levels scorecards only).",
 			NestedObject: schema.NestedAttributeObject{
@@ -140,7 +138,7 @@ func ScorecardSchema() map[string]schema.Attribute {
 		},
 
 		// Conditionally required for points-based scorecards
-		"check_groups": schema.ListNestedAttribute{
+		"check_groups": schema.MapNestedAttribute{
 			Optional:    true,
 			Description: "Groups of checks, to help organize the scorecard for entity owners (points scorecards only).",
 			NestedObject: schema.NestedAttributeObject{

--- a/dx/scorecard/schema.go
+++ b/dx/scorecard/schema.go
@@ -46,7 +46,6 @@ func CheckSchema() map[string]schema.Attribute {
 				stringplanmodifier.UseStateForUnknown(),
 			},
 		},
-		"key":                schema.StringAttribute{Required: true, Description: "The Terraform key for the check. This makes it possible to preserve history when reordering checks."},
 		"name":               schema.StringAttribute{Required: true},
 		"description":        schema.StringAttribute{Required: true},
 		"ordering":           schema.Int32Attribute{Required: true},
@@ -169,7 +168,7 @@ func ScorecardSchema() map[string]schema.Attribute {
 		},
 
 		// For now, all check field are required. This may change in the future.
-		"checks": schema.SetNestedAttribute{
+		"checks": schema.MapNestedAttribute{
 			Optional:    true,
 			Description: "List of checks that are applied to entities in the scorecard.",
 			NestedObject: schema.NestedAttributeObject{

--- a/dx/scorecard/schema.go
+++ b/dx/scorecard/schema.go
@@ -46,6 +46,7 @@ func CheckSchema() map[string]schema.Attribute {
 				stringplanmodifier.UseStateForUnknown(),
 			},
 		},
+		"key":                schema.StringAttribute{Required: true, Description: "The Terraform key for the check. This makes it possible to preserve history when reordering checks."},
 		"name":               schema.StringAttribute{Required: true},
 		"description":        schema.StringAttribute{Required: true},
 		"ordering":           schema.Int32Attribute{Required: true},
@@ -168,7 +169,7 @@ func ScorecardSchema() map[string]schema.Attribute {
 		},
 
 		// For now, all check field are required. This may change in the future.
-		"checks": schema.ListNestedAttribute{
+		"checks": schema.SetNestedAttribute{
 			Optional:    true,
 			Description: "List of checks that are applied to entities in the scorecard.",
 			NestedObject: schema.NestedAttributeObject{

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     dx = {
       source  = "registry.terraform.io/get-dx/dx"
-      version = "0.1.0"
+      version = "~> 0.1.0"
     }
   }
 }
@@ -29,28 +29,26 @@ resource "dx_scorecard" "my_example_scorecard" {
   empty_level_color              = "#cccccc"
   published                      = true
 
-  levels = [
-    {
-      key   = "bronze"
+  levels = {
+    bronze = {
       name  = "Bronze"
       color = "#FB923C"
       rank  = 1
     },
-    {
-      key   = "silver"
+    silver = {
       name  = "Silver"
       color = "#9CA3AF"
       rank  = 2
     },
-    {
-      key   = "gold"
+    gold = {
       name  = "Gold"
       color = "#FBBF24"
       rank  = 3
     },
-  ]
-  checks = [
-    {
+  }
+
+  checks = {
+    test_check = {
       name                = "Test Check"
       scorecard_level_key = "bronze"
       ordering            = 0
@@ -71,7 +69,7 @@ resource "dx_scorecard" "my_example_scorecard" {
       filter_sql            = ""
       output_custom_options = null
     },
-    {
+    another_check = {
       name                = "Another Check"
       scorecard_level_key = "silver"
       ordering            = 0
@@ -99,5 +97,5 @@ resource "dx_scorecard" "my_example_scorecard" {
       filter_sql            = ""
       output_custom_options = null
     }
-  ]
+  }
 }

--- a/examples/resources/dx_scorecard/resource.tf
+++ b/examples/resources/dx_scorecard/resource.tf
@@ -9,7 +9,7 @@ terraform {
 
 provider "dx" {}
 
-resource "dx_scorecard" "example" {
+resource "dx_scorecard" "level_based_example" {
   name                           = "Terraform Provider Scorecard"
   description                    = "This is a test scorecard"
   type                           = "LEVEL"
@@ -20,26 +20,24 @@ resource "dx_scorecard" "example" {
   empty_level_color              = "#cccccc"
   published                      = true
 
-  levels = [
-    {
-      key   = "bronze"
+  levels = {
+    bronze = {
       name  = "Bronze"
       color = "#FB923C"
       rank  = 1
     },
-    {
-      key   = "silver"
+    silver = {
       name  = "Silver"
       color = "#9CA3AF"
       rank  = 2
     },
-    {
-      key   = "gold"
+    gold = {
       name  = "Gold"
       color = "#FBBF24"
       rank  = 3
     },
-  ]
+  }
+
   checks = {
     test_check = {
       name                = "Test Check"
@@ -108,6 +106,69 @@ resource "dx_scorecard" "example" {
       filter_message        = ""
       filter_sql            = ""
       output_custom_options = null
+    },
+  }
+}
+
+resource "dx_scorecard" "points_based_example" {
+  name                           = "Terraform Provider Scorecard - points"
+  description                    = "This is a test scorecard"
+  type                           = "POINTS"
+  entity_filter_type             = "entity_types"
+  entity_filter_type_identifiers = ["service"]
+  evaluation_frequency_hours     = 2
+  published                      = true
+
+  check_groups = {
+    group_1 = {
+      name     = "First group"
+      ordering = 0
+    },
+    group_2 = {
+      name     = "Second group"
+      ordering = 1
+    },
+  }
+
+  checks = {
+    check_1 = {
+      name                      = "Check 1"
+      scorecard_check_group_key = "group_1"
+      ordering                  = 0
+
+      description           = "This is a check in the first group"
+      sql                   = <<-EOT
+        select 'PASS' as status, 123 as output
+      EOT
+      output_enabled        = false
+      external_url          = "http://example.com"
+      published             = true
+      estimated_dev_days    = 1.5
+      filter_message        = ""
+      filter_sql            = ""
+      output_custom_options = null
+      points                = 10
+    },
+
+    check_2 = {
+      name                      = "Check 2"
+      scorecard_check_group_key = "group_2"
+      ordering                  = 0
+
+      description           = "This is a check in the second group"
+      sql                   = <<-EOT
+        select 'PASS' as status, 123 as output
+      EOT
+      output_enabled        = true
+      output_type           = "duration_seconds"
+      output_aggregation    = "median"
+      external_url          = "http://example.com"
+      published             = true
+      estimated_dev_days    = 1.5
+      filter_message        = ""
+      filter_sql            = ""
+      output_custom_options = null
+      points                = 20
     },
   }
 }

--- a/examples/resources/dx_scorecard/resource.tf
+++ b/examples/resources/dx_scorecard/resource.tf
@@ -40,8 +40,8 @@ resource "dx_scorecard" "example" {
       rank  = 3
     },
   ]
-  checks = [
-    {
+  checks = {
+    test_check = {
       name                = "Test Check"
       scorecard_level_key = "bronze"
       ordering            = 0
@@ -60,10 +60,11 @@ resource "dx_scorecard" "example" {
       filter_sql            = ""
       output_custom_options = null
     },
-    {
+
+    another_check = {
       name                = "Another Check"
-      scorecard_level_key = "silver"
-      ordering            = 0
+      scorecard_level_key = "bronze"
+      ordering            = 1
 
       description           = "This is a another test check"
       sql                   = <<-EOT
@@ -87,6 +88,26 @@ resource "dx_scorecard" "example" {
       filter_message        = ""
       filter_sql            = ""
       output_custom_options = null
-    }
-  ]
+    },
+
+    neat_silver_check = {
+      name                = "Neat silver check"
+      scorecard_level_key = "silver"
+      ordering            = 0
+
+      description           = "This is a neat silver check"
+      sql                   = <<-EOT
+        select 'PASS' as status, 123 as output
+      EOT
+      output_enabled        = true
+      output_type           = "duration_seconds"
+      output_aggregation    = "median"
+      external_url          = "http://example.com"
+      published             = true
+      estimated_dev_days    = 1.5
+      filter_message        = ""
+      filter_sql            = ""
+      output_custom_options = null
+    },
+  }
 }


### PR DESCRIPTION
This restructures the `dx_scorecard` resource to support preserving check history after reorders. The following list-based attributes have changed to be maps:

- `levels`
- `check_groups`
- `checks`

Previously, the level and check group models both had a `key` attribute, but now those are the **map keys** for the higher-level scorecard attributes. Since checks is now a map as well, this requires the user to begin defining keys for checks, to make their identities stable.

Our API expects each these three scorecard attributes to be lists, but we store them as maps. So we have to convert back and forth. Here is how that process works in `resource.go`:

- `modelToRequestBody`: Minimal change. We were previously looping over the items in a list, but now we loop over the key-value entries in the map.

- `responseBodyToModel`: This change is more complex. Our API responses do not include the `key` of any of these objects, so it is up to us to match them up. Fortunately, the API sorts the levels, check groups, and checks deterministically based on their `ordering`/`rank`, and we can run similar sorting in the provider to reliably match up an item in the state with an item from an API response. This lets us know which pieces of state to update.