### PR TITLE
Add support for output custom options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Added support for `output_custom_options` in a check.
+
+## [0.3.0] - 2025-06-12
+
+### Added
+
 - Added support for `tags` on a scorecard.
 
 ### Changed
@@ -71,6 +79,7 @@ Initial published release.
 - Provider
 - `dx_scorecard` resource
 
+[0.3.0]: https://github.com/get-dx/terraform-provider-dx/compare/v0.2.2...v0.3.0
 [0.2.2]: https://github.com/get-dx/terraform-provider-dx/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/get-dx/terraform-provider-dx/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/get-dx/terraform-provider-dx/compare/v0.1.2...v0.2.0

--- a/docs/index.md
+++ b/docs/index.md
@@ -67,29 +67,26 @@ resource "dx_scorecard" "my_example_scorecard" {
       scorecard_level_key = "bronze"
       ordering            = 0
 
-      description           = "This is a test check"
-      sql                   = <<-EOT
+      description        = "This is a test check"
+      sql                = <<-EOT
         select
           'PASS' as status,
           123 as output
       EOT
-      output_enabled        = true
-      output_type           = "duration_seconds"
-      output_aggregation    = "median"
-      external_url          = "http://example.com"
-      published             = true
-      estimated_dev_days    = 1.5
-      filter_message        = ""
-      filter_sql            = ""
-      output_custom_options = null
+      output_enabled     = true
+      output_type        = "duration_seconds"
+      output_aggregation = "median"
+      external_url       = "http://example.com"
+      published          = true
+      estimated_dev_days = 1.5
     },
     another_check = {
       name                = "Another Check"
       scorecard_level_key = "silver"
       ordering            = 0
 
-      description           = "This is a another test check"
-      sql                   = <<-EOT
+      description        = "This is a another test check"
+      sql                = <<-EOT
         with random_number as (
           select ROUND(RANDOM() * 10) as value
         )
@@ -101,15 +98,11 @@ resource "dx_scorecard" "my_example_scorecard" {
           value as output
         from random_number
       EOT
-      output_enabled        = true
-      output_type           = "duration_seconds"
-      output_aggregation    = "median"
-      external_url          = "http://example.com"
-      published             = false
-      estimated_dev_days    = null
-      filter_message        = ""
-      filter_sql            = ""
-      output_custom_options = null
+      output_enabled     = true
+      output_type        = "duration_seconds"
+      output_aggregation = "median"
+      external_url       = "http://example.com"
+      published          = false
     }
   }
 }

--- a/docs/resources/scorecard.md
+++ b/docs/resources/scorecard.md
@@ -59,17 +59,20 @@ resource "dx_scorecard" "level_based_example" {
       scorecard_level_key = "bronze"
       ordering            = 0
 
-      description           = "This is a test check"
-      sql                   = <<-EOT
+      description    = "This is a test check"
+      sql            = <<-EOT
         select 'PASS' as status, 123 as output
       EOT
-      output_enabled        = true
-      output_type           = "duration_seconds"
-      output_aggregation    = "median"
-      external_url          = "http://example.com"
-      published             = true
-      estimated_dev_days    = 1.5
-      output_custom_options = null
+      output_enabled = true
+      output_type    = "custom"
+      output_custom_options = {
+        unit     = "widget"
+        decimals = 0
+      }
+      output_aggregation = "median"
+      external_url       = "http://example.com"
+      published          = true
+      estimated_dev_days = 1.5
     },
 
     another_check = {
@@ -77,7 +80,7 @@ resource "dx_scorecard" "level_based_example" {
       scorecard_level_key = "bronze"
       ordering            = 1
 
-      sql                   = <<-EOT
+      sql                = <<-EOT
         with random_number as (
           select ROUND(RANDOM() * 10) as value
         )
@@ -89,12 +92,11 @@ resource "dx_scorecard" "level_based_example" {
           value as output
         from random_number
       EOT
-      output_enabled        = true
-      output_type           = "duration_seconds"
-      output_aggregation    = "median"
-      published             = false
-      estimated_dev_days    = null
-      output_custom_options = null
+      output_enabled     = true
+      output_type        = "duration_seconds"
+      output_aggregation = "median"
+      published          = false
+      estimated_dev_days = null
     },
 
     neat_silver_check = {
@@ -102,14 +104,13 @@ resource "dx_scorecard" "level_based_example" {
       scorecard_level_key = "silver"
       ordering            = 0
 
-      description           = "This is a neat silver check"
-      sql                   = <<-EOT
+      description        = "This is a neat silver check"
+      sql                = <<-EOT
         select 'PASS' as status
       EOT
-      output_enabled        = false
-      published             = false
-      estimated_dev_days    = 1.5
-      output_custom_options = null
+      output_enabled     = false
+      published          = false
+      estimated_dev_days = 1.5
     },
   }
 }
@@ -140,16 +141,15 @@ resource "dx_scorecard" "points_based_example" {
       scorecard_check_group_key = "group_1"
       ordering                  = 0
 
-      description           = "This is a check in the first group"
-      sql                   = <<-EOT
+      description        = "This is a check in the first group"
+      sql                = <<-EOT
         select 'PASS' as status
       EOT
-      output_enabled        = false
-      external_url          = "http://example.com"
-      published             = true
-      estimated_dev_days    = 1.5
-      output_custom_options = null
-      points                = 10
+      output_enabled     = false
+      external_url       = "http://example.com"
+      published          = true
+      estimated_dev_days = 1.5
+      points             = 10
     },
 
     check_2 = {
@@ -157,17 +157,16 @@ resource "dx_scorecard" "points_based_example" {
       scorecard_check_group_key = "group_2"
       ordering                  = 0
 
-      sql                   = <<-EOT
+      sql                = <<-EOT
         select 'PASS' as status, 123 as output
       EOT
-      output_enabled        = true
-      output_type           = "duration_seconds"
-      output_aggregation    = "median"
-      external_url          = "http://example.com"
-      published             = true
-      estimated_dev_days    = 1.5
-      output_custom_options = null
-      points                = 20
+      output_enabled     = true
+      output_type        = "duration_seconds"
+      output_aggregation = "median"
+      external_url       = "http://example.com"
+      published          = true
+      estimated_dev_days = 1.5
+      points             = 20
     },
   }
 }
@@ -246,8 +245,11 @@ Read-Only:
 
 Required:
 
-- `decimals` (Number) The number of decimals to display, or `auto` for default behavior.
 - `unit` (String) The unit of the output, e.g. `widget`
+
+Optional:
+
+- `decimals` (Number) The number of decimals to display. If omitted or set to `null`, it will be interpreted as "auto".
 
 
 

--- a/dx/dxapi/scorecard.go
+++ b/dx/dxapi/scorecard.go
@@ -75,8 +75,37 @@ type APICheck struct {
 }
 
 type APIOutputCustomOptions struct {
-	Unit     string `json:"unit"`
-	Decimals *int32 `json:"decimals"` // TODO: "auto" or number
+	Unit     string            `json:"unit"`
+	Decimals APICustomDecimals `json:"decimals"`
+}
+
+type APICustomDecimals struct {
+	IsAuto     bool
+	FixedValue *int32
+}
+
+func (ios *APICustomDecimals) UnmarshalJSON(data []byte) error {
+	// Try to unmarshal as int32
+	var intVal int32
+	if err := json.Unmarshal(data, &intVal); err == nil {
+		ios.FixedValue = &intVal
+		ios.IsAuto = false
+		return nil
+	}
+
+	// Try to unmarshal as string
+	var strVal string
+	if err := json.Unmarshal(data, &strVal); err == nil {
+		if strVal == "auto" {
+			ios.FixedValue = nil
+			ios.IsAuto = true
+			return nil
+		} else {
+			return fmt.Errorf("APICustomDecimals: value is neither int32 nor the string 'auto': %s", string(data))
+		}
+	}
+
+	return fmt.Errorf("APICustomDecimals: value is neither int32 nor the string 'auto': %s", string(data))
 }
 
 // APIResponse is the top-level response from the DX API for scorecard endpoints.

--- a/dx/scorecard/model.go
+++ b/dx/scorecard/model.go
@@ -52,9 +52,9 @@ type CheckModel struct {
 	FilterMessage types.String `tfsdk:"filter_message"`
 	OutputEnabled types.Bool   `tfsdk:"output_enabled"`
 
-	OutputType          types.String `tfsdk:"output_type"`
-	OutputAggregation   types.String `tfsdk:"output_aggregation"`
-	OutputCustomOptions types.Object `tfsdk:"output_custom_options"` //TODO figure out how to model this
+	OutputType          types.String              `tfsdk:"output_type"`
+	OutputAggregation   types.String              `tfsdk:"output_aggregation"`
+	OutputCustomOptions *OutputCustomOptionsModel `tfsdk:"output_custom_options"`
 
 	EstimatedDevDays types.Float32 `tfsdk:"estimated_dev_days"`
 	ExternalUrl      types.String  `tfsdk:"external_url"`
@@ -66,4 +66,9 @@ type CheckModel struct {
 	// Additional fields for points based scorecards
 	ScorecardCheckGroupKey types.String `tfsdk:"scorecard_check_group_key"`
 	Points                 types.Int32  `tfsdk:"points"`
+}
+
+type OutputCustomOptionsModel struct {
+	Unit     types.String `tfsdk:"unit"`
+	Decimals types.Int32  `tfsdk:"decimals"`
 }

--- a/dx/scorecard/resource.go
+++ b/dx/scorecard/resource.go
@@ -544,7 +544,6 @@ func responseBodyToModel(ctx context.Context, apiResp *dxapi.APIResponse, state 
 
 		var outputCustomOptions *OutputCustomOptionsModel = nil
 		if chk.OutputCustomOptions != nil {
-			var decimalsValue *int32 = nil
 			decimals := chk.OutputCustomOptions.Decimals
 			if decimals.IsAuto {
 				outputCustomOptions = &OutputCustomOptionsModel{
@@ -552,10 +551,10 @@ func responseBodyToModel(ctx context.Context, apiResp *dxapi.APIResponse, state 
 					Decimals: types.Int32Null(),
 				}
 			} else {
-				decimalsValue = decimals.FixedValue
+				decimalsValue := *decimals.FixedValue
 				outputCustomOptions = &OutputCustomOptionsModel{
 					Unit:     types.StringValue(chk.OutputCustomOptions.Unit),
-					Decimals: types.Int32Value(*decimalsValue),
+					Decimals: types.Int32Value(decimalsValue),
 				}
 			}
 		}

--- a/dx/scorecard/schema.go
+++ b/dx/scorecard/schema.go
@@ -57,7 +57,7 @@ func CheckSchema() map[string]schema.Attribute {
 			Optional: true,
 			Attributes: map[string]schema.Attribute{
 				"unit":     schema.StringAttribute{Required: true, Description: "The unit of the output, e.g. `widget`"},
-				"decimals": schema.NumberAttribute{Required: true, Description: "The number of decimals to display, or `auto` for default behavior."},
+				"decimals": schema.Int32Attribute{Optional: true, Description: "The number of decimals to display. If omitted or set to `null`, it will be interpreted as \"auto\"."},
 			},
 		},
 		"estimated_dev_days": schema.Float32Attribute{Optional: true},

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -53,26 +53,26 @@ resource "dx_scorecard" "my_example_scorecard" {
       scorecard_level_key = "bronze"
       ordering            = 0
 
-      description           = "This is a test check"
-      sql                   = <<-EOT
+      description        = "This is a test check"
+      sql                = <<-EOT
         select
           'PASS' as status,
           123 as output
       EOT
-      output_enabled        = true
-      output_type           = "duration_seconds"
-      output_aggregation    = "median"
-      external_url          = "http://example.com"
-      published             = true
-      estimated_dev_days    = 1.5
+      output_enabled     = true
+      output_type        = "duration_seconds"
+      output_aggregation = "median"
+      external_url       = "http://example.com"
+      published          = true
+      estimated_dev_days = 1.5
     },
     another_check = {
       name                = "Another Check"
       scorecard_level_key = "silver"
       ordering            = 0
 
-      description           = "This is a another test check"
-      sql                   = <<-EOT
+      description        = "This is a another test check"
+      sql                = <<-EOT
         with random_number as (
           select ROUND(RANDOM() * 10) as value
         )
@@ -84,11 +84,11 @@ resource "dx_scorecard" "my_example_scorecard" {
           value as output
         from random_number
       EOT
-      output_enabled        = true
-      output_type           = "duration_seconds"
-      output_aggregation    = "median"
-      external_url          = "http://example.com"
-      published             = false
+      output_enabled     = true
+      output_type        = "duration_seconds"
+      output_aggregation = "median"
+      external_url       = "http://example.com"
+      published          = false
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -65,9 +65,6 @@ resource "dx_scorecard" "my_example_scorecard" {
       external_url          = "http://example.com"
       published             = true
       estimated_dev_days    = 1.5
-      filter_message        = ""
-      filter_sql            = ""
-      output_custom_options = null
     },
     another_check = {
       name                = "Another Check"
@@ -92,10 +89,6 @@ resource "dx_scorecard" "my_example_scorecard" {
       output_aggregation    = "median"
       external_url          = "http://example.com"
       published             = false
-      estimated_dev_days    = null
-      filter_message        = ""
-      filter_sql            = ""
-      output_custom_options = null
     }
   }
 }

--- a/examples/resources/dx_scorecard/resource.tf
+++ b/examples/resources/dx_scorecard/resource.tf
@@ -49,12 +49,15 @@ resource "dx_scorecard" "level_based_example" {
         select 'PASS' as status, 123 as output
       EOT
       output_enabled        = true
-      output_type           = "duration_seconds"
+      output_type           = "custom"
+      output_custom_options = {
+        unit     = "widget"
+        decimals = 0
+      }
       output_aggregation    = "median"
       external_url          = "http://example.com"
       published             = true
       estimated_dev_days    = 1.5
-      output_custom_options = null
     },
 
     another_check = {
@@ -79,7 +82,6 @@ resource "dx_scorecard" "level_based_example" {
       output_aggregation    = "median"
       published             = false
       estimated_dev_days    = null
-      output_custom_options = null
     },
 
     neat_silver_check = {
@@ -94,7 +96,6 @@ resource "dx_scorecard" "level_based_example" {
       output_enabled        = false
       published             = false
       estimated_dev_days    = 1.5
-      output_custom_options = null
     },
   }
 }
@@ -133,7 +134,6 @@ resource "dx_scorecard" "points_based_example" {
       external_url          = "http://example.com"
       published             = true
       estimated_dev_days    = 1.5
-      output_custom_options = null
       points                = 10
     },
 
@@ -151,7 +151,6 @@ resource "dx_scorecard" "points_based_example" {
       external_url          = "http://example.com"
       published             = true
       estimated_dev_days    = 1.5
-      output_custom_options = null
       points                = 20
     },
   }

--- a/examples/resources/dx_scorecard/resource.tf
+++ b/examples/resources/dx_scorecard/resource.tf
@@ -44,20 +44,20 @@ resource "dx_scorecard" "level_based_example" {
       scorecard_level_key = "bronze"
       ordering            = 0
 
-      description           = "This is a test check"
-      sql                   = <<-EOT
+      description    = "This is a test check"
+      sql            = <<-EOT
         select 'PASS' as status, 123 as output
       EOT
-      output_enabled        = true
-      output_type           = "custom"
+      output_enabled = true
+      output_type    = "custom"
       output_custom_options = {
         unit     = "widget"
         decimals = 0
       }
-      output_aggregation    = "median"
-      external_url          = "http://example.com"
-      published             = true
-      estimated_dev_days    = 1.5
+      output_aggregation = "median"
+      external_url       = "http://example.com"
+      published          = true
+      estimated_dev_days = 1.5
     },
 
     another_check = {
@@ -65,7 +65,7 @@ resource "dx_scorecard" "level_based_example" {
       scorecard_level_key = "bronze"
       ordering            = 1
 
-      sql                   = <<-EOT
+      sql                = <<-EOT
         with random_number as (
           select ROUND(RANDOM() * 10) as value
         )
@@ -77,11 +77,11 @@ resource "dx_scorecard" "level_based_example" {
           value as output
         from random_number
       EOT
-      output_enabled        = true
-      output_type           = "duration_seconds"
-      output_aggregation    = "median"
-      published             = false
-      estimated_dev_days    = null
+      output_enabled     = true
+      output_type        = "duration_seconds"
+      output_aggregation = "median"
+      published          = false
+      estimated_dev_days = null
     },
 
     neat_silver_check = {
@@ -89,13 +89,13 @@ resource "dx_scorecard" "level_based_example" {
       scorecard_level_key = "silver"
       ordering            = 0
 
-      description           = "This is a neat silver check"
-      sql                   = <<-EOT
+      description        = "This is a neat silver check"
+      sql                = <<-EOT
         select 'PASS' as status
       EOT
-      output_enabled        = false
-      published             = false
-      estimated_dev_days    = 1.5
+      output_enabled     = false
+      published          = false
+      estimated_dev_days = 1.5
     },
   }
 }
@@ -126,15 +126,15 @@ resource "dx_scorecard" "points_based_example" {
       scorecard_check_group_key = "group_1"
       ordering                  = 0
 
-      description           = "This is a check in the first group"
-      sql                   = <<-EOT
+      description        = "This is a check in the first group"
+      sql                = <<-EOT
         select 'PASS' as status
       EOT
-      output_enabled        = false
-      external_url          = "http://example.com"
-      published             = true
-      estimated_dev_days    = 1.5
-      points                = 10
+      output_enabled     = false
+      external_url       = "http://example.com"
+      published          = true
+      estimated_dev_days = 1.5
+      points             = 10
     },
 
     check_2 = {
@@ -142,16 +142,16 @@ resource "dx_scorecard" "points_based_example" {
       scorecard_check_group_key = "group_2"
       ordering                  = 0
 
-      sql                   = <<-EOT
+      sql                = <<-EOT
         select 'PASS' as status, 123 as output
       EOT
-      output_enabled        = true
-      output_type           = "duration_seconds"
-      output_aggregation    = "median"
-      external_url          = "http://example.com"
-      published             = true
-      estimated_dev_days    = 1.5
-      points                = 20
+      output_enabled     = true
+      output_type        = "duration_seconds"
+      output_aggregation = "median"
+      external_url       = "http://example.com"
+      published          = true
+      estimated_dev_days = 1.5
+      points             = 20
     },
   }
 }


### PR DESCRIPTION
This adds support for `output_custom_options` on checks. We previously only accepted `null` values, but now we can accept either of these styles:

```terraform
# "Auto" precision
output_custom_options = {
  unit = "widget"
}

# Fixed precision
output_custom_options = {
  unit     = "widget"
  decimals = 0
}
```