### PR TITLE
Only set output_aggregation in request when present in plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Fixed a bug where `check.output_aggregation` would send `""` in requests even if it was `null` in the plan.
+
 ## [0.3.1] - 2025-06-13
 
 ### Added

--- a/dx/scorecard/resource.go
+++ b/dx/scorecard/resource.go
@@ -403,8 +403,11 @@ func modelToRequestBody(ctx context.Context, plan ScorecardModel, setIds bool) (
 		}
 
 		if checkPayload["output_enabled"] == true {
-			checkPayload["output_type"] = planCheck.OutputType.ValueString()
-			checkPayload["output_aggregation"] = planCheck.OutputAggregation.ValueString()
+			outputType := planCheck.OutputType.ValueString()
+			checkPayload["output_type"] = outputType
+			if isNumericOutputType(outputType) {
+				checkPayload["output_aggregation"] = planCheck.OutputAggregation.ValueString()
+			}
 		}
 
 		if planCheck.OutputType.ValueString() == "custom" {
@@ -732,4 +735,8 @@ func nameToKey(ctx context.Context, name string) string {
 	result := strcase.ToSnake(name)
 	tflog.Info(ctx, fmt.Sprintf("Converted name `%s` to key `%s`", name, result))
 	return result
+}
+
+func isNumericOutputType(outputType string) bool {
+	return outputType != "string"
 }

--- a/dx/scorecard/resource.go
+++ b/dx/scorecard/resource.go
@@ -403,8 +403,7 @@ func modelToRequestBody(ctx context.Context, plan ScorecardModel, setIds bool) (
 		}
 
 		if checkPayload["output_enabled"] == true {
-			outputType := planCheck.OutputType.ValueString()
-			checkPayload["output_type"] = outputType
+			checkPayload["output_type"] = planCheck.OutputType.ValueString()
 			if !planCheck.OutputAggregation.IsNull() {
 				checkPayload["output_aggregation"] = planCheck.OutputAggregation.ValueString()
 			}

--- a/dx/scorecard/resource.go
+++ b/dx/scorecard/resource.go
@@ -405,7 +405,7 @@ func modelToRequestBody(ctx context.Context, plan ScorecardModel, setIds bool) (
 		if checkPayload["output_enabled"] == true {
 			outputType := planCheck.OutputType.ValueString()
 			checkPayload["output_type"] = outputType
-			if isNumericOutputType(outputType) {
+			if !planCheck.OutputAggregation.IsNull() {
 				checkPayload["output_aggregation"] = planCheck.OutputAggregation.ValueString()
 			}
 		}
@@ -735,8 +735,4 @@ func nameToKey(ctx context.Context, name string) string {
 	result := strcase.ToSnake(name)
 	tflog.Info(ctx, fmt.Sprintf("Converted name `%s` to key `%s`", name, result))
 	return result
-}
-
-func isNumericOutputType(outputType string) bool {
-	return outputType != "string"
 }


### PR DESCRIPTION
This fixes a bug where each check's `output_aggregation` was always getting set to a string value in requests, even if it was null in the plan.