### PR TITLE
Chore: Show error message if DX_WEB_API_TOKEN is not available

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,8 +23,6 @@ env:
   DX_WEB_API_URL: ${{ secrets.DX_WEB_API_URL }}
   DX_WEB_API_TOKEN: ${{ secrets.DX_WEB_API_TOKEN }}
 
-# PLACEHOLDER EDIT
-
 jobs:
   # Ensure project builds before running testing matrix
   build:
@@ -62,7 +60,11 @@ jobs:
           git diff --compact-summary --exit-code || \
             (echo; echo "Unexpected difference in directories after code generation. Run 'make generate' command and commit."; exit 1)
 
-  # Run acceptance tests in a matrix with Terraform CLI versions
+  # Run acceptance tests in a matrix with Terraform CLI versions.
+  # Secrets are unavailable for pull_request events from forks. The first step
+  # fails with an actionable message so maintainers know to approve the run via
+  # the Actions tab (or enable "Require approval for all outside collaborators"
+  # in repo Settings → Actions → General → Fork pull request workflows).
   test:
     name: Terraform Provider Acceptance Tests
     needs: build
@@ -75,6 +77,11 @@ jobs:
         terraform:
           - "1.14.*"
     steps:
+      - name: Check for required secrets
+        if: env.DX_WEB_API_TOKEN == ''
+        run: |
+          echo "::error::Acceptance tests require DX_WEB_API_TOKEN. Maintainers: review the code, then approve this workflow run to run with secrets: https://docs.github.com/en/actions/how-tos/manage-workflow-runs/approve-runs-from-forks"
+          exit 1
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,8 @@ env:
   DX_WEB_API_URL: ${{ secrets.DX_WEB_API_URL }}
   DX_WEB_API_TOKEN: ${{ secrets.DX_WEB_API_TOKEN }}
 
+# PLACEHOLDER EDIT
+
 jobs:
   # Ensure project builds before running testing matrix
   build:


### PR DESCRIPTION
This makes a change to our GitHub Actions workflow so that if the `DX_WEB_API_TOKEN` secret is not available (from public forks), then maintainers need to manually review and approve it to run. This protects us from the risk of leaking tokens.

<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev couldn't review this pull request</strong>
The pull request author does not have access to Rovo Dev.
<!-- /Rovo Dev code review status -->

