### PR TITLE
Chore: Use `acceptance-tests` environment when running tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,12 +4,25 @@ name: Tests
 # This GitHub action runs your tests for each pull request and push.
 # Optionally, you can turn it on using a schedule for regular testing.
 on:
-  # pull_request_target runs in the base repo context and has access to secrets,
-  # which is required for acceptance tests. Forks still require maintainer
-  # approval before the workflow runs (configure in repo Settings → Actions →
-  # General → Fork pull request workflows → "Require approval for all outside
-  # collaborators"). Always pin checkout to github.event.pull_request.head.sha
+  # Same-repo PRs (from coworkers) use pull_request — secrets are available
+  # automatically and no approval gate is needed.
+  #
+  # Fork PRs (from external contributors) use pull_request_target, which runs
+  # in the base repo context and therefore has access to secrets. The test job
+  # uses the acceptance-tests environment, which requires maintainer approval
+  # before it runs, so untrusted code is reviewed before credentials are used.
+  # Configure required reviewers in repo Settings → Environments →
+  # acceptance-tests. Always pin checkout to github.event.pull_request.head.sha
   # so we test the PR code, not main.
+  #
+  # Both triggers are listed to cover both cases. Each job has an `if` condition
+  # to skip the duplicate run that would otherwise occur for same-repo PRs
+  # (which fire both pull_request and pull_request_target).
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - "README.md"
+      - "CHANGELOG.md"
   pull_request_target:
     branches: [main]
     paths-ignore:
@@ -31,6 +44,10 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    if: >-
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository)
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -49,6 +66,10 @@ jobs:
 
   generate:
     runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository)
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -80,6 +101,10 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    if: >-
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository)
     # Only gate on the acceptance-tests environment (which requires maintainer
     # approval) when the PR comes from a fork. Same-repo PRs from coworkers
     # have secrets available via pull_request_target without an approval gate.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,13 @@ name: Tests
 # This GitHub action runs your tests for each pull request and push.
 # Optionally, you can turn it on using a schedule for regular testing.
 on:
-  pull_request:
+  # pull_request_target runs in the base repo context and has access to secrets,
+  # which is required for acceptance tests. Forks still require maintainer
+  # approval before the workflow runs (configure in repo Settings → Actions →
+  # General → Fork pull request workflows → "Require approval for all outside
+  # collaborators"). Always pin checkout to github.event.pull_request.head.sha
+  # so we test the PR code, not main.
+  pull_request_target:
     branches: [main]
     paths-ignore:
       - "README.md"
@@ -19,10 +25,6 @@ on:
 permissions:
   contents: read
 
-env:
-  DX_WEB_API_URL: ${{ secrets.DX_WEB_API_URL }}
-  DX_WEB_API_TOKEN: ${{ secrets.DX_WEB_API_TOKEN }}
-
 jobs:
   # Ensure project builds before running testing matrix
   build:
@@ -31,6 +33,9 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version-file: "go.mod"
@@ -46,6 +51,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version-file: "go.mod"
@@ -61,15 +69,21 @@ jobs:
             (echo; echo "Unexpected difference in directories after code generation. Run 'make generate' command and commit."; exit 1)
 
   # Run acceptance tests in a matrix with Terraform CLI versions.
-  # Secrets are unavailable for pull_request events from forks. The first step
-  # fails with an actionable message so maintainers know to approve the run via
-  # the Actions tab (or enable "Require approval for all outside collaborators"
-  # in repo Settings → Actions → General → Fork pull request workflows).
+  # Secrets are scoped to the "acceptance-tests" GitHub Environment, which
+  # requires maintainer approval before the job runs. This ensures untrusted
+  # fork code is reviewed before it executes with credentials.
+  # Setup: repo Settings → Environments → acceptance-tests → add required
+  # reviewers, then move DX_WEB_API_URL and DX_WEB_API_TOKEN to environment
+  # secrets (Settings → Environments → acceptance-tests → Environment secrets).
   test:
     name: Terraform Provider Acceptance Tests
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    environment: acceptance-tests
+    env:
+      DX_WEB_API_URL: ${{ secrets.DX_WEB_API_URL }}
+      DX_WEB_API_TOKEN: ${{ secrets.DX_WEB_API_TOKEN }}
     strategy:
       fail-fast: false
       matrix:
@@ -77,12 +91,10 @@ jobs:
         terraform:
           - "1.14.*"
     steps:
-      - name: Check for required secrets
-        if: env.DX_WEB_API_TOKEN == ''
-        run: |
-          echo "::error::Acceptance tests require DX_WEB_API_TOKEN. Maintainers: review the code, then approve this workflow run to run with secrets: https://docs.github.com/en/actions/how-tos/manage-workflow-runs/approve-runs-from-forks"
-          exit 1
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version-file: "go.mod"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,7 +80,11 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    environment: acceptance-tests
+    # Only gate on the acceptance-tests environment (which requires maintainer
+    # approval) when the PR comes from a fork. Same-repo PRs from coworkers
+    # have secrets available via pull_request_target without an approval gate.
+    # push events evaluate to '' (no environment), which is also fine.
+    environment: ${{ (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository) && 'acceptance-tests' || '' }}
     env:
       DX_WEB_API_URL: ${{ secrets.DX_WEB_API_URL }}
       DX_WEB_API_TOKEN: ${{ secrets.DX_WEB_API_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,11 +105,7 @@ jobs:
       github.event_name == 'push' ||
       (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
       (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository)
-    # Only gate on the acceptance-tests environment (which requires maintainer
-    # approval) when the PR comes from a fork. Same-repo PRs from coworkers
-    # have secrets available via pull_request_target without an approval gate.
-    # push events evaluate to '' (no environment), which is also fine.
-    environment: ${{ (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository) && 'acceptance-tests' || '' }}
+    environment: acceptance-tests
     env:
       DX_WEB_API_URL: ${{ secrets.DX_WEB_API_URL }}
       DX_WEB_API_TOKEN: ${{ secrets.DX_WEB_API_TOKEN }}


### PR DESCRIPTION
This changes our test workflow to use the repo's `acceptance-tests` environment. I've defined `DX_WEB_API_TOKEN` and `DX_WEB_API_URL` secrets in that environment, and the other changes to this workflow should make it possible to reference those secrets, even from a PR coming from a fork. See [this article](https://2i2c.org/blog/github-action-secrets-forked-repositories/) for more info.
<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev couldn't review this pull request</strong>
The pull request author does not have access to Rovo Dev.
<!-- /Rovo Dev code review status -->

