### PR TITLE
dx_scorecard resource: allow passing null for entity_filter_sql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- `dx_scorecard` resource: Added support to clear a previously-set `entity_filter_sql` field.
+
 ## [0.9.0] - 2026-04-16
 
 ### Changed

--- a/dx/scorecard/resource.go
+++ b/dx/scorecard/resource.go
@@ -433,7 +433,7 @@ func modelToRequestBody(ctx context.Context, plan ScorecardModel, setIds bool) (
 		}
 		payload["entity_filter_type_identifiers"] = identifiers
 	}
-	if !plan.EntityFilterSql.IsNull() && !plan.EntityFilterSql.IsUnknown() {
+	if !plan.EntityFilterSql.IsUnknown() {
 		payload["entity_filter_sql"] = plan.EntityFilterSql.ValueString()
 	}
 


### PR DESCRIPTION
This fixes a bug with the `dx_scorecard` resource where explicit plans for `entity_filter_sql = null` were being ignored and not being sent to the API.



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

