### PR TITLE
Add support for alias instance identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- BREAKING: Each alias entry in the `dx_entity` and `dx_entities` data sources now requires an `instance_identifier` field (e.g. a specific GitHub Enterprise Server deployment). If you have two or more connections to the same type of system, you will need this field to disambiguate the instance each alias comes from.
+
+  To migrate, add `instance_identifier` to each alias entry:
+
+  ```diff
+  resource "dx_entity" "payment_service" {
+    identifier     = "payment-service"
+
+    # ...
+
+    aliases = {
+      github_repo = [
+        {
+          identifier          = "1234567890"
+  +       instance_identifier = null
+        }
+      ]
+      pagerduty_service = [
+        {
+          identifier          = "PD12345"
+  +       instance_identifier = null
+        }
+      ]
+    }
+  }
+  ```
+
 ## [0.10.0] - 2026-05-29
 
 ### Added

--- a/docs/data-sources/entity.md
+++ b/docs/data-sources/entity.md
@@ -92,7 +92,7 @@ output "production_status" {
 
 ### Read-Only
 
-- `aliases` (Map of List of Object) Key-value pairs of aliases assigned to the entity. Keys are alias types (e.g., 'github_repo'), values are arrays of alias objects with 'identifier' field.
+- `aliases` (Map of List of Object) Key-value pairs of aliases assigned to the entity. Keys are alias types (e.g., 'github_repo'), values are arrays of alias objects with 'identifier' and optional 'instance_identifier' fields.
 - `created_at` (String) Timestamp when the entity was created.
 - `description` (String) Description of the entity.
 - `domain` (String) The identifier of the domain entity parent assigned to the entity.

--- a/docs/resources/entity.md
+++ b/docs/resources/entity.md
@@ -45,12 +45,14 @@ resource "dx_entity" "payment_service" {
   aliases = {
     github_repo = [
       {
-        identifier = "1234567890"
+        identifier          = "1234567890"
+        instance_identifier = null
       }
     ]
     pagerduty_service = [
       {
-        identifier = "PD12345"
+        identifier          = "PD12345"
+        instance_identifier = null
       }
     ]
   }
@@ -75,7 +77,8 @@ resource "dx_entity" "user_api" {
   aliases = {
     github_repo = [
       {
-        identifier = "962275774"
+        identifier          = "962275774"
+        instance_identifier = null
       }
     ]
   }
@@ -92,7 +95,7 @@ resource "dx_entity" "user_api" {
 
 ### Optional
 
-- `aliases` (Map of List of Object) Key-value pairs of aliases assigned to the entity. Keys are alias types (e.g., 'github_repo'), values are arrays of alias objects with 'identifier' (required) field.
+- `aliases` (Map of List of Object) Key-value pairs of aliases assigned to the entity. Keys are alias types (e.g., 'github_repo'), values are arrays of alias objects with 'identifier' (required) and 'instance_identifier' (optional) fields.
 - `description` (String) Description of the entity.
 - `domain` (String) The identifier of the domain entity parent assigned to the entity.
 - `name` (String) Display name for the entity.

--- a/dx/dxapi/entity.go
+++ b/dx/dxapi/entity.go
@@ -44,7 +44,8 @@ type APIDomain struct {
 }
 
 type APIAlias struct {
-	Identifier string `json:"identifier"`
+	Identifier         string  `json:"identifier"`
+	InstanceIdentifier *string `json:"instance_identifier,omitempty"`
 }
 
 // APIEntityResponse is the top-level response from the DX API for entity endpoints.

--- a/dx/entity/datasource.go
+++ b/dx/entity/datasource.go
@@ -88,12 +88,13 @@ func (d *EntityDataSource) Schema(ctx context.Context, req datasource.SchemaRequ
 				ElementType: types.ListType{
 					ElemType: types.ObjectType{
 						AttrTypes: map[string]attr.Type{
-							"identifier": types.StringType,
+							"identifier":          types.StringType,
+							"instance_identifier": types.StringType,
 						},
 					},
 				},
 				Computed:    true,
-				Description: "Key-value pairs of aliases assigned to the entity. Keys are alias types (e.g., 'github_repo'), values are arrays of alias objects with 'identifier' field.",
+				Description: "Key-value pairs of aliases assigned to the entity. Keys are alias types (e.g., 'github_repo'), values are arrays of alias objects with 'identifier' and optional 'instance_identifier' fields.",
 			},
 			"created_at": schema.StringAttribute{
 				Computed:    true,
@@ -272,8 +273,15 @@ func mapAPIResponseToDataSourceModel(ctx context.Context, apiResp *dxapi.APIEnti
 		for aliasType, aliasArray := range apiResp.Entity.Aliases {
 			aliasModels := make([]AliasModel, 0, len(aliasArray))
 			for _, alias := range aliasArray {
+				var instanceID types.String
+				if alias.InstanceIdentifier != nil {
+					instanceID = types.StringValue(*alias.InstanceIdentifier)
+				} else {
+					instanceID = types.StringNull()
+				}
 				aliasModel := AliasModel{
-					Identifier: types.StringValue(alias.Identifier),
+					Identifier:         types.StringValue(alias.Identifier),
+					InstanceIdentifier: instanceID,
 				}
 				aliasModels = append(aliasModels, aliasModel)
 			}

--- a/dx/entity/datasource_entities.go
+++ b/dx/entity/datasource_entities.go
@@ -121,7 +121,8 @@ func (d *EntitiesDataSource) Schema(ctx context.Context, req datasource.SchemaRe
 							ElementType: types.ListType{
 								ElemType: types.ObjectType{
 									AttrTypes: map[string]attr.Type{
-										"identifier": types.StringType,
+										"identifier":          types.StringType,
+										"instance_identifier": types.StringType,
 									},
 								},
 							},
@@ -283,8 +284,15 @@ func mapAPIEntityToEntitiesModel(ctx context.Context, entity *dxapi.APIEntity, s
 		for aliasType, aliasArray := range entity.Aliases {
 			aliasModels := make([]AliasModel, 0, len(aliasArray))
 			for _, alias := range aliasArray {
+				var instanceID types.String
+				if alias.InstanceIdentifier != nil {
+					instanceID = types.StringValue(*alias.InstanceIdentifier)
+				} else {
+					instanceID = types.StringNull()
+				}
 				aliasModels = append(aliasModels, AliasModel{
-					Identifier: types.StringValue(alias.Identifier),
+					Identifier:         types.StringValue(alias.Identifier),
+					InstanceIdentifier: instanceID,
 				})
 			}
 			if len(aliasModels) > 0 {

--- a/dx/entity/datasource_test.go
+++ b/dx/entity/datasource_test.go
@@ -131,7 +131,7 @@ resource "dx_entity" "test" {
   type        = "service"
   name        = "%s"
   description = "Test entity for data source"
-  
+
   properties = {
     tier = "Tier-1"
   }
@@ -152,17 +152,18 @@ resource "dx_entity" "test_props" {
   type        = "service"
   name        = "%s"
   description = "Entity with properties and aliases"
-  
+
   properties = {
     tier        = "Tier-1"
     language    = ["Go", "TypeScript"]
     environment = "production"
   }
-  
+
   aliases = {
     github_repo = [
       {
-        identifier = "520637360"
+        identifier          = "520637360"
+        instance_identifier = null
       }
     ]
   }

--- a/dx/entity/resource.go
+++ b/dx/entity/resource.go
@@ -441,6 +441,10 @@ func addAliasesToPayload(payload map[string]interface{}, plan EntityResourceMode
 					alias := dxapi.APIAlias{
 						Identifier: aliasModel.Identifier.ValueString(),
 					}
+					if !aliasModel.InstanceIdentifier.IsNull() && !aliasModel.InstanceIdentifier.IsUnknown() {
+						v := aliasModel.InstanceIdentifier.ValueString()
+						alias.InstanceIdentifier = &v
+					}
 					apiAliasArray = append(apiAliasArray, alias)
 				}
 			}
@@ -543,7 +547,8 @@ func responseBodyToModel(ctx context.Context, apiResp *dxapi.APIEntityResponse, 
 			aliasModels := make([]AliasModel, 0, len(aliasArray))
 			for _, alias := range aliasArray {
 				aliasModel := AliasModel{
-					Identifier: types.StringValue(alias.Identifier),
+					Identifier:         types.StringValue(alias.Identifier),
+					InstanceIdentifier: dx.StringOrNull(alias.InstanceIdentifier),
 				}
 				aliasModels = append(aliasModels, aliasModel)
 			}

--- a/dx/entity/resource_model.go
+++ b/dx/entity/resource_model.go
@@ -27,6 +27,6 @@ type EntityResourceModel struct {
 
 // AliasModel describes an alias entry for an entity.
 type AliasModel struct {
-	Identifier types.String `tfsdk:"identifier"` // Required: the alias identifier
+	Identifier         types.String `tfsdk:"identifier"`          // Required: the alias identifier
 	InstanceIdentifier types.String `tfsdk:"instance_identifier"` // Optional: the instance identifier
 }

--- a/dx/entity/resource_model.go
+++ b/dx/entity/resource_model.go
@@ -28,4 +28,5 @@ type EntityResourceModel struct {
 // AliasModel describes an alias entry for an entity.
 type AliasModel struct {
 	Identifier types.String `tfsdk:"identifier"` // Required: the alias identifier
+	InstanceIdentifier types.String `tfsdk:"instance_identifier"` // Optional: the instance identifier
 }

--- a/dx/entity/resource_schema.go
+++ b/dx/entity/resource_schema.go
@@ -17,6 +17,10 @@ func AliasSchema() map[string]schema.Attribute {
 			Required:    true,
 			Description: "The unique identifier for the alias (e.g., GitHub repository ID).",
 		},
+		"instance_identifier": schema.StringAttribute{
+			Optional:    true,
+			Description: "An optional instance identifier for the alias (e.g. GitHub Enterprise Server instance ID).",
+		},
 		"name": schema.StringAttribute{
 			Computed:    true,
 			Description: "The name of the alias (computed from the Data Cloud database).",
@@ -78,12 +82,13 @@ func EntityResourceSchema() map[string]schema.Attribute {
 			ElementType: types.ListType{
 				ElemType: types.ObjectType{
 					AttrTypes: map[string]attr.Type{
-						"identifier": types.StringType,
+						"identifier":          types.StringType,
+						"instance_identifier": types.StringType,
 					},
 				},
 			},
 			Optional:    true,
-			Description: "Key-value pairs of aliases assigned to the entity. Keys are alias types (e.g., 'github_repo'), values are arrays of alias objects with 'identifier' (required) field.",
+			Description: "Key-value pairs of aliases assigned to the entity. Keys are alias types (e.g., 'github_repo'), values are arrays of alias objects with 'identifier' (required) and 'instance_identifier' (optional) fields.",
 		},
 		"created_at": schema.StringAttribute{
 			Computed:    true,

--- a/dx/entity/resource_test.go
+++ b/dx/entity/resource_test.go
@@ -31,7 +31,8 @@ resource "dx_entity" "tf-integration-test" {
   aliases = {
     github_repo = [
       {
-        identifier = "520637360"
+        identifier          = "520637360"
+        instance_identifier = null
       }
     ]
   }
@@ -81,10 +82,12 @@ resource "dx_entity" "tf-integration-test" {
   aliases = {
     github_repo = [
       {
-        identifier = "520637360"
+        identifier          = "520637360"
+        instance_identifier = null
       },
       {
-        identifier = "962275774"
+        identifier          = "962275774"
+        instance_identifier = null
       }
     ]
   }
@@ -182,7 +185,8 @@ resource "dx_entity" "optional" {
   aliases = {
     github_repo = [
       {
-        identifier = "962275774"
+        identifier          = "962275774"
+        instance_identifier = null
       }
     ]
   }

--- a/examples/resources/dx_entity/resource.tf
+++ b/examples/resources/dx_entity/resource.tf
@@ -30,12 +30,14 @@ resource "dx_entity" "payment_service" {
   aliases = {
     github_repo = [
       {
-        identifier = "1234567890"
+        identifier          = "1234567890"
+        instance_identifier = null
       }
     ]
     pagerduty_service = [
       {
-        identifier = "PD12345"
+        identifier          = "PD12345"
+        instance_identifier = null
       }
     ]
   }
@@ -60,7 +62,8 @@ resource "dx_entity" "user_api" {
   aliases = {
     github_repo = [
       {
-        identifier = "962275774"
+        identifier          = "962275774"
+        instance_identifier = null
       }
     ]
   }


### PR DESCRIPTION
This adds support for the optional `instance_identifier` field in [alias](https://docs.getdx.com/webapi/types/aliases/) entries.

Note that this will need to be a **breaking change**, since we will now require `instance_identifier` to be set, even if it is `null`. I tried to use a `DynamicAttribute` but ran into conflicts with the `entries` attribute:

```
Dynamic types inside of collections are not currently supported in terraform-plugin-framework. If underlying dynamic values are required, replace the "entities" attribute definition with DynamicAttribute instead...
```

<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

